### PR TITLE
Hotfix minibatch

### DIFF
--- a/include/parpeoptimization/minibatchOptimization.h
+++ b/include/parpeoptimization/minibatchOptimization.h
@@ -695,7 +695,7 @@ public:
                            double cost1, 
                            double cost2, 
                            double dirGradient,
-                           auto costFunEvaluate) {
+                           std::function<double (double)> costFunEvaluate) {
 
         /* From here on, we will use cubic interpolation.
          * We need to compute the matrix-vector multiplication


### PR DESCRIPTION
Fixing a parameter assignment, which worked locally but not on the superMuc