### PR TITLE
adapt dataprovider and simulatio to df to third column in simulation …

### DIFF
--- a/python/parpe/dataprovider.py
+++ b/python/parpe/dataprovider.py
@@ -45,12 +45,14 @@ class DataProvider:
             y[:, :] = self._get_measurement_sigmas(f, condition_idx)
             edata.setObservedDataStdDev(y.flatten())
 
-            preeq_cond_idx, sim_cond_idx = \
+            preeq_cond_idx, sim_cond_idx, reinit_states_flag = \
                 self._get_fixed_par_indices(f, condition_idx)
             edata.fixedParameters = self._get_fixed_parameters(f, sim_cond_idx)
             if preeq_cond_idx > 0:
                 edata.fixedParametersPreequilibration = \
                     self._get_fixed_parameters(f, preeq_cond_idx)
+            if reinit_states_flag > 0:
+                edata.reinitializeFixedParameterInitialStates = True
 
         return edata
 
@@ -60,9 +62,9 @@ class DataProvider:
 
     @staticmethod
     def _get_fixed_par_indices(f, simulation_idx):
-        preeq_cond_idx, sim_cond_idx = \
+        preeq_cond_idx, sim_cond_idx, reinit_states_flag = \
             f['/fixedParameters/simulationConditions'][simulation_idx, :]
-        return preeq_cond_idx, sim_cond_idx
+        return preeq_cond_idx, sim_cond_idx, reinit_states_flag
 
     @staticmethod
     def _get_measurements(f, simulation_idx):

--- a/python/parpe/misc.py
+++ b/python/parpe/misc.py
@@ -337,7 +337,8 @@ def simulation_to_df(mes_df, sim, result_file, start, observable_ids,
         (condition_names[preeq_idx] if not np.isnan(
             preeq_idx) and preeq_idx >= 0 else -1.0,
          condition_names[sim_idx] if sim_idx >= 0 else -1.0): comb_idx
-        for comb_idx, (preeq_idx, sim_idx) in enumerate(simulation_conditions)}
+        for comb_idx, (preeq_idx, sim_idx, _) in enumerate(
+            simulation_conditions)}
     obs_id_to_idx = {id_: idx for idx, id_ in enumerate(observable_ids)}
 
     mes_df[MEASUREMENT] = np.nan


### PR DESCRIPTION
simulationConditions has got a third column now in the parPE input files, which indicates state reinitialization after preequilibration.
However, some routines are not yet adapted to this third column. This PR should fix that.