### PR TITLE
Fix reading variable length strings from h5py

### DIFF
--- a/examples/parpeamici/steadystate/create_steadystate_amici_model.py
+++ b/examples/parpeamici/steadystate/create_steadystate_amici_model.py
@@ -303,7 +303,7 @@ def save_expected_results(hdf5_file_name, true_parameters_dict, expected_llh):
     # write true parameters
     with h5py.File(hdf5_file_name, 'r+') as f:
         true_parameters = [true_parameters_dict[p] for p in
-                           f['/parameters/parameterNames']]
+                           f['/parameters/parameterNames'].asstr()]
         f.require_dataset(
             '/parameters/true_parameters',
             shape=(len(true_parameters),), dtype="f8", data=true_parameters)
@@ -318,7 +318,7 @@ def write_starting_points(hdf5_file_name, true_parameters):
     with h5py.File(hdf5_file_name, 'r+') as f:
         pscale = f['/parameters/pscaleOptimization'][:]
         true_parameters_scaled = np.array([true_parameters[p] for p in
-                           f['/parameters/parameterNames']])
+                           f['/parameters/parameterNames'].asstr()])
         for i, p in enumerate(pscale):
             if p == amici.ParameterScaling_log10:
                 true_parameters_scaled[i] = np.log10(true_parameters_scaled[i])

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ setup(
                       'colorama>=0.4.3',
                       'petab>=0.1.7',
                       'amici>=0.11.2',
-                      'h5py>=2.10.0',
+                      'h5py>=3.0.0',
                       'python-libsbml>=5.17.0',
                       'jinja2>=2.11.1',
                       'snakemake>=5.10.0'


### PR DESCRIPTION
From h5py 3.0.0 on, strings are read as `bytes` instrad of `str`, so we need to convert.