### PR TITLE
Ensure buffer memory is deallocated ...

### DIFF
--- a/src/parpeamici/multiConditionProblem.cpp
+++ b/src/parpeamici/multiConditionProblem.cpp
@@ -537,7 +537,7 @@ FunctionEvaluationStatus getModelOutputsAndSigmas(
         auto results =
                 amici::deserializeFromChar<AmiciSummedGradientFunction::ResultMap> (
                     job->recvBuffer.data(), job->recvBuffer.size());
-        job->recvBuffer = std::vector<char>(); // free buffer
+        std::vector<char>().swap(job->recvBuffer); // free buffer
 
         for (auto const& result : results) {
             errors += result.second.status;
@@ -788,7 +788,7 @@ int AmiciSummedGradientFunction::aggregateLikelihood(
     auto results =
             amici::deserializeFromChar<ResultMap> (
                 data.recvBuffer.data(), data.recvBuffer.size());
-    data.recvBuffer = std::vector<char>(); // free buffer
+    std::vector<char>().swap(data.recvBuffer); // free buffer
 
 
     for (auto const& result : results) {

--- a/src/parpeamici/standaloneSimulator.cpp
+++ b/src/parpeamici/standaloneSimulator.cpp
@@ -168,7 +168,7 @@ StandaloneSimulator::run(const std::string& resultFile,
                     std::map<int,
                              AmiciSimulationRunner::AmiciResultPackageSimple>>(
                     job.recvBuffer.data(), job.recvBuffer.size());
-                job.recvBuffer = std::vector<char>(); // free buffer
+                std::vector<char>().swap(job.recvBuffer); // free buffer
                 for (auto& result : results) {
                     swap(simulationResults[result.first], result.second);
                     modelOutputs[result.first] =
@@ -293,7 +293,7 @@ StandaloneSimulator::run(const std::string& resultFile,
                     int,
                     AmiciSimulationRunner::AmiciResultPackageSimple>>(
                     job->recvBuffer.data(), job->recvBuffer.size());
-                job->recvBuffer = std::vector<char>(); // free buffer
+                std::vector<char>().swap(job->recvBuffer); // free buffer
 
                 for (auto const& result : results) {
                     errors += result.second.status;

--- a/src/parpeloadbalancer/loadBalancerMaster.cpp
+++ b/src/parpeloadbalancer/loadBalancerMaster.cpp
@@ -99,7 +99,7 @@ void LoadBalancerMaster::freeEmptiedSendBuffers() {
             /* By the time we check for send to be finished, we might have received the reply
              * already and the pointed-to object might have been already destroyed. This
              * is therefore set to nullptr when receiving the reply. */
-            sentJobsData[emptiedBufferIdx]->sendBuffer = std::vector<char>();
+            std::vector<char>().swap(sentJobsData[emptiedBufferIdx]->sendBuffer);
         } else {
             break;
         }


### PR DESCRIPTION
... after completing sending, and after result has been used.

Should reduce RSS HWM.