### PR TITLE
Update ipopt installation guide/script

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ ThirdParty/installDeps.sh
 NOTE: When using `ThirdParty/installIpopt.sh` to build Ipopt, you may have to
 download the HSL library separately as described at
 https://coin-or.github.io/Ipopt/INSTALL.html#DOWNLOAD_HSL. Place the HSL
-archive into `ThirdParty` before running `ThirdParty/installIpopt.sh`.
+archive into `ThirdParty` before running `ThirdParty/installIpopt.sh`. If asked
+type in your coinhsl version (e.g. `2019.05.21` if you
+have `coinhsl-2019.05.21.tar.gz`).
 
 
 ## Building

--- a/ThirdParty/installDeps.sh
+++ b/ThirdParty/installDeps.sh
@@ -15,3 +15,5 @@ cd "$script_dir"
 ./installCeres.sh
 
 ./installIpopt.sh
+
+./installGoogleTest.sh

--- a/ThirdParty/installIpopt.sh
+++ b/ThirdParty/installIpopt.sh
@@ -45,7 +45,7 @@ if [[ ! -d "${ipopt_dir}" ]]; then
       read version
       if [[ -f "${script_dir}/coinhsl-${version}.tar.gz" ]]; then
       	tar -xzf "${script_dir}/coinhsl-${version}.tar.gz"
-      	mv coinhsl-2015.06.23 coinhsl
+      	mv coinhsl-${version} coinhsl
       else
       	echo "Press any key to continue"
       	read -n 1 -s -r

--- a/ThirdParty/installIpopt.sh
+++ b/ThirdParty/installIpopt.sh
@@ -36,13 +36,20 @@ if [[ ! -d "${ipopt_dir}" ]]; then
     if [[ -f "${script_dir}/coinhsl-2015.06.23.tar.gz" ]]; then
       tar -xzf "${script_dir}/coinhsl-2015.06.23.tar.gz"
       mv coinhsl-2015.06.23 coinhsl
-    elif [[ -f "${script_dir}/coinhsl-2014.01.10.tar.gz" ]]; then
-      tar -xzf "${script_dir}/coinhsl-2014.01.10.tar.gz"
-      mv coinhsl-2014.01.10 coinhsl
+    elif [[ -f "${script_dir}/coinhsl-2019.05.21.tar.gz" ]]; then
+      tar -xzf "${script_dir}/coinhsl-2019.05.21.tar.gz"
+      mv coinhsl-2019.05.21 coinhsl
     else
       echo "Did not find coinhsl/ or a known coinhsl archive."
-      echo "Press any key to continue"
-      read -n 1 -s -r
+      echo "Name your coinhsl version."
+      read version
+      if [[ -f "${script_dir}/coinhsl-${version}.tar.gz" ]]; then
+      	tar -xzf "${script_dir}/coinhsl-${version}.tar.gz"
+      	mv coinhsl-2015.06.23 coinhsl
+      else
+      	echo "Press any key to continue"
+      	read -n 1 -s -r
+      fi
     fi
   fi
 

--- a/ThirdParty/installIpopt.sh
+++ b/ThirdParty/installIpopt.sh
@@ -36,6 +36,9 @@ if [[ ! -d "${ipopt_dir}" ]]; then
     if [[ -f "${script_dir}/coinhsl-2015.06.23.tar.gz" ]]; then
       tar -xzf "${script_dir}/coinhsl-2015.06.23.tar.gz"
       mv coinhsl-2015.06.23 coinhsl
+    elif [[ -f "${script_dir}/coinhsl-2014.01.10.tar.gz" ]]; then
+      tar -xzf "${script_dir}/coinhsl-2014.01.10.tar.gz"
+      mv coinhsl-2014.01.10 coinhsl
     elif [[ -f "${script_dir}/coinhsl-2019.05.21.tar.gz" ]]; then
       tar -xzf "${script_dir}/coinhsl-2019.05.21.tar.gz"
       mv coinhsl-2019.05.21 coinhsl


### PR DESCRIPTION
These are the things i noticed when installing:
1. When installing Ipopt, it was checked for only two specific versions of hsl. I updated the older one to mine (should be the newest) but also added the option to manually type in your version (also updated in `Readme.md`)
2. When using `buildAll.sh` it told me it was missing the Google tests. While it also said to run `installGoogleTest.sh` i thought it might be easier to just include it in `buildAll.sh`.