### PR TITLE
enabled commandline with number of indices as argument

### DIFF
--- a/include/parpeamici/optimizationApplication.h
+++ b/include/parpeamici/optimizationApplication.h
@@ -149,16 +149,17 @@ private:
 protected:
     // command line option parsing
     const char *shortOptions = "dhvmt:o:s:";
-    struct option const longOptions[9] = {
-        {"debug", no_argument, nullptr, 'd'},
-        {"print-worklist", no_argument, nullptr, 'p'},
-        {"help", no_argument, nullptr, 'h'},
-        {"version", no_argument, nullptr, 'v'},
-        {"mpi", no_argument, nullptr, 'm'},
-        {"task", required_argument, nullptr, 't'},
-        {"outfile-prefix", required_argument, nullptr, 'o'},
-        {"first-start-idx", required_argument, nullptr, 's'},
-        {nullptr, 0, nullptr, 0}};
+    struct option const longOptions[10] = {
+        {"debug", no_argument, NULL, 'd'},
+        {"print-worklist", no_argument, NULL, 'p'},
+        {"help", no_argument, NULL, 'h'},
+        {"version", no_argument, NULL, 'v'},
+        {"mpi", no_argument, NULL, 'm'},
+        {"task", required_argument, NULL, 't'},
+        {"gradient-check", required_argument, NULL, 'g'},
+        {"outfile-prefix", required_argument, NULL, 'o'},
+        {"first-start-idx", required_argument, NULL, 's'},
+        {NULL, 0, NULL, 0}};
 
     enum class OperationType {
         parameterEstimation,
@@ -175,6 +176,7 @@ protected:
     std::unique_ptr<OptimizationProblem> problem;
     H5::H5File h5File = 0;
     OperationType operationType = OperationType::parameterEstimation;
+    int num_parameter_checks = 1;
     LoadBalancerMaster loadBalancer;
     bool withMPI = false;
 };


### PR DESCRIPTION
So i think this should work as a first draft, i would need to enable parsing comma separated ids or indices as well, which i will try to finish this week. Also i noticed that the option `-t` should basically only be used when we want to perform a gradient check? I would suggest removing `-t` and going for `-g` for the gradient check. But could also be that i missed something.