### PR TITLE
Add option to specify maximum number of threads for multi-start optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For full functionality, parPE requires the following libraries:
 * IPOPT (>= 1.2.7) (requires coinhsl)
 * CERES (>=1.13)
   ([requires Eigen](http://ceres-solver.org/installation.html#dependencies))
-* [Bosst](https://www.boost.org/) (serialization, thread)
+* [Boost](https://www.boost.org/) (serialization, thread)
 * HDF5 (>= 1.10)
 * CBLAS compatible BLAS (libcblas, Intel MKL, ...)
 * [AMICI](https://github.com/ICB-DCM/AMICI) (included in this repository)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For full functionality, parPE requires the following libraries:
 * IPOPT (>= 1.2.7) (requires coinhsl)
 * CERES (>=1.13)
   ([requires Eigen](http://ceres-solver.org/installation.html#dependencies))
+* [Bosst](https://www.boost.org/) (serialization, thread)
 * HDF5 (>= 1.10)
 * CBLAS compatible BLAS (libcblas, Intel MKL, ...)
 * [AMICI](https://github.com/ICB-DCM/AMICI) (included in this repository)
@@ -64,10 +65,21 @@ For full functionality, parPE requires the following libraries:
 
 On Debian-based systems, dependencies can be installed via:
 ```shell
-sudo apt-get install build-essential cmake cmake-curses-gui \
-    coinor-libipopt-dev curl gfortran \
-    libblas-dev libboost-serialization-dev libceres-dev \
-    libmpich-dev libhdf5-dev libpython3-dev python3-pip
+sudo apt-get install \
+  build-essential \
+  cmake \
+  cmake-curses-gui \
+  coinor-libipopt-dev \
+  curl \
+  gfortran \
+  libblas-dev \
+  libboost-serialization-dev \
+  libboost-thread-dev \
+  libceres-dev \
+  libmpich-dev \
+  libhdf5-dev \
+  libpython3-dev \
+  python3-pip
 ```
 
 Scripts to fetch and build the remaining dependencies are provided in

--- a/doc/optimizationApplication.md
+++ b/doc/optimizationApplication.md
@@ -44,6 +44,13 @@ Run the created executable with the `-h`/`--help` argument.
 
 ## Environment variables
 
+- **PARPE_NUM_PARALLEL_STARTS**
+
+  Setting `PARPE_NUM_PARALLEL_STARTS=n` will create a maximum of `n` threads
+  for concurrent local optimizations during multi-start optimization.
+  If unset, this defaults to the number of concurrent threads supported by
+  hardware.
+
 - **PARPE_LOG_SIMULATIONS**
 
   Setting `PARPE_LOG_SIMULATIONS=1` will cause every single AMICI simulation to be saved in the result files.

--- a/include/parpeoptimization/multiStartOptimization.h
+++ b/include/parpeoptimization/multiStartOptimization.h
@@ -45,7 +45,7 @@ class MultiStartOptimization {
     /**
      * @brief Run all optimizations in parallel, each in a dedicated thread
      */
-    void runMultiThreaded();
+    void runMultiThreaded() const;
 
     /**
      * @brief Run optimizations sequentially

--- a/include/parpeoptimization/multiStartOptimization.h
+++ b/include/parpeoptimization/multiStartOptimization.h
@@ -59,8 +59,6 @@ class MultiStartOptimization {
 
   private:
 
-    std::vector<OptimizationProblem *> createLocalOptimizationProblems();
-
     /** Optimization problem to be solved */
     MultiStartOptimizationProblem& msProblem;
 

--- a/include/parpeoptimization/multiStartOptimization.h
+++ b/include/parpeoptimization/multiStartOptimization.h
@@ -58,6 +58,11 @@ class MultiStartOptimization {
     void setRunParallel(bool runParallel);
 
   private:
+    /**
+     * @brief Optimize local problem for the given start index
+     */
+    int runStart(int start_idx) const;
+
 
     /** Optimization problem to be solved */
     MultiStartOptimizationProblem& msProblem;

--- a/include/parpeoptimization/optimizationProblem.h
+++ b/include/parpeoptimization/optimizationProblem.h
@@ -217,15 +217,6 @@ private:
 int getLocalOptimum(OptimizationProblem *problem);
 
 
-/**
- * @brief getLocalOptimumThreadWrapper wrapper for using getLocalOptimum with
- * pThreads.
- * @param optimizationProblemVp
- * @return Pointer to int indicating status. 0: success, != 0: failure
- */
-
-void *getLocalOptimumThreadWrapper(void *optimizationProblemVp);
-
 void optimizationProblemGradientCheckMultiEps(OptimizationProblem *problem,
                                               int numParameterIndicesToCheck);
 

--- a/src/parpeamici/CMakeLists.txt
+++ b/src/parpeamici/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
     # For python module we need -fPIC which is only the case with shared libs
     set(Boost_USE_STATIC_LIBS FALSE)
 endif()
-find_package(Boost COMPONENTS serialization REQUIRED)
+find_package(Boost COMPONENTS serialization thread REQUIRED)
 
 
 project(parpeamici)

--- a/src/parpeoptimization/multiStartOptimization.cpp
+++ b/src/parpeoptimization/multiStartOptimization.cpp
@@ -6,9 +6,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <pthread.h>
-#include <unistd.h>
-#include <cassert>
 #include <future>
 
 namespace parpe {
@@ -115,11 +112,9 @@ void MultiStartOptimization::runMultiThreaded()
                                        "Starting local optimization #%d",
                                        start_idx);
 
-                            auto problem = msProblem.getLocalProblem(
-                                start_idx);
+                            auto problem = msProblem.getLocalProblem(start_idx);
                             return std::make_pair(
-                                start_idx,
-                                getLocalOptimum(problem.get()));
+                                start_idx, getLocalOptimum(problem.get()));
                         }));
             }
         }

--- a/src/parpeoptimization/multiStartOptimization.cpp
+++ b/src/parpeoptimization/multiStartOptimization.cpp
@@ -34,7 +34,8 @@ void MultiStartOptimization::run() {
 void MultiStartOptimization::runMultiThreaded() const
 {
     // Determine thread pool size
-    auto num_threads = std::thread::hardware_concurrency();
+    // (note that hardware_concurrency() may return 0)
+    auto num_threads = std::max(std::thread::hardware_concurrency(), 1U);
     if(auto env = std::getenv("PARPE_NUM_PARALLEL_STARTS")) {
         num_threads = std::stoi(env);
     }

--- a/src/parpeoptimization/multiStartOptimization.cpp
+++ b/src/parpeoptimization/multiStartOptimization.cpp
@@ -162,15 +162,4 @@ void MultiStartOptimization::setRunParallel(bool runParallel)
     this->runParallel = runParallel;
 }
 
-std::vector<OptimizationProblem *>
-MultiStartOptimization::createLocalOptimizationProblems() {
-    std::vector<OptimizationProblem *> localProblems(numberOfStarts);
-
-    for (int ms = 0; ms < numberOfStarts; ++ms) {
-        localProblems[ms] = msProblem.getLocalProblem(first_start_idx + ms).release();
-    }
-
-    return localProblems;
-}
-
 } // namespace parpe

--- a/src/parpeoptimization/optimizationProblem.cpp
+++ b/src/parpeoptimization/optimizationProblem.cpp
@@ -47,13 +47,6 @@ int getLocalOptimum(OptimizationProblem *problem) {
 }
 
 
-void *getLocalOptimumThreadWrapper(void *optimizationProblemVp) {
-    auto problem = static_cast<OptimizationProblem *>(optimizationProblemVp);
-    auto *result = new int;
-    *result = getLocalOptimum(problem);
-    return result;
-}
-
 void optimizationProblemGradientCheckMultiEps(OptimizationProblem *problem,
                                       int numParameterIndicesToCheck
                                       ) {


### PR DESCRIPTION
So far, this was equal to the number of local optimizations, but that wouldn't scale well.

This decouples the number parallel local optimizations from the total number of optimizations.

This is controlled by setting environment variable `PARPE_NUM_PARALLEL_STARTS` to the number
of optimizations that should be run in parallel.

Now requires Boost.Thread library

Closes #359, closes #84