### PR TITLE
GHA: Attempt dockerhub upload only if secrets are accessible

### DIFF
--- a/.github/workflows/deploy_dockerhub.yml
+++ b/.github/workflows/deploy_dockerhub.yml
@@ -2,6 +2,21 @@
 name: Deploy to dockerhub
 on: [push, workflow_dispatch]
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      secrets-defined: ${{ steps.secret-check.outputs.defined }}
+    steps:
+      - name: Check for Secret availability
+        id: secret-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.DOCKER_USERNAME }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   build:
     name: Deploy to dockerhub
     runs-on: ubuntu-latest
@@ -9,6 +24,7 @@ jobs:
     - uses: actions/checkout@master
     - run: git archive -v -o container/charliecloud/parpe_base/parpe.tar.gz --format=tar.gz HEAD
     - name: Publish to Registry
+      if: needs.check-secret.outputs.secrets-defined == 'true'
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: dweindl/parpe


### PR DESCRIPTION
e.g., they won't be accessible during builds for dependabot PRs.