### PR TITLE
Fix RTD build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ extensions = [
     # 'recommonmark',
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting',
-    'm2r2',
+    'myst_parser',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -3,7 +3,7 @@ sphinx_rtd_theme>=1.2.0
 breathe>=4.35.0
 exhale>=0.2.3
 ipython>=8.13.2
-m2r2>=0.2.7
+myst-parser
 sphinx-autodoc-typehints>=1.10.3
 nbsphinx==0.9.1
 nbconvert>=7.1.0

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -6,6 +6,7 @@ ipython>=8.13.2
 m2r2>=0.2.7
 sphinx-autodoc-typehints>=1.10.3
 nbsphinx==0.9.1
+nbconvert>=7.1.0
 -e git+https://github.com/svenevs/exhale.git@a1a8551321e246e3ab81f5456e04a8159804595b#egg=exhale
 
 # to import parpe package:


### PR DESCRIPTION
* Require `nbconvert>=7.1.0`
  
  Fixes:
  ```
    File "/home/docs/checkouts/readthedocs.org/user_builds/parpe/envs/385/lib/python3.11/site-packages/nbconvert/exporters/templateexporter.py", line 25, in <module>
      from lxml.html.clean import clean_html
    File "/home/docs/checkouts/readthedocs.org/user_builds/parpe/envs/385/lib/python3.11/site-packages/lxml/html/clean.py", line 18, in <module>
      raise ImportError(
  ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
  Install lxml[html_clean] or lxml_html_clean directly.
  ```

* m2r2 -> myst-parser
  
  Fixes:
  ```
    File "/home/docs/checkouts/readthedocs.org/user_builds/parpe/envs/386/lib/python3.11/site-packages/m2r2.py", line 14, in <module>
      from docutils.core import ErrorString
  ImportError: cannot import name 'ErrorString' from 'docutils.core' (/home/docs/checkouts/readthedocs.org/user_builds/parpe/envs/386/lib/python3.11/site-packages/docutils/core.py)
  ```