### PR TITLE
Use Ubuntu 24.04

### DIFF
--- a/.github/workflows/benchmark_models.yml
+++ b/.github/workflows/benchmark_models.yml
@@ -35,10 +35,6 @@ jobs:
             -DBUILD_TESTS=OFF \
           && cmake --build "${AMICI_PATH}/build" --parallel -- VERBOSE=1
 
-    - name: Install parPE Python deps
-      run: |
-        pip install -r ${PARPE_BASE}/python/requirements.txt
-
     - name: Configure parpe
       run: |
         cmake \

--- a/.github/workflows/parpe_tests.yml
+++ b/.github/workflows/parpe_tests.yml
@@ -98,8 +98,6 @@ jobs:
     #  run: cd ${PARPE_BUILD} && CTEST_OUTPUT_ON_FAILURE=1 make test
 
     - name: Create coverage report
-      env:
-        LD_DEBUG: bindings
       run: |
         cd ${PARPE_BUILD} \
           && CTEST_OUTPUT_ON_FAILURE=1 make parpe_coverage \

--- a/.github/workflows/parpe_tests.yml
+++ b/.github/workflows/parpe_tests.yml
@@ -18,7 +18,6 @@ jobs:
       # If we are running in docker, we generally don't have SYS_PTRACE
       #  permissions  and thus, cannot use vader. Also disable Infiniband.
       PARPE_TESTS_MPIEXEC: mpiexec -n 5 --oversubscribe --allow-run-as-root --mca btl_vader_single_copy_mechanism none --mca btl ^openib --mca oob_tcp_if_include lo --mca btl_tcp_if_include lo --mca orte_base_help_aggregate 0
-
     steps:
     - uses: actions/checkout@master
     - name: chown checkout directory
@@ -99,6 +98,8 @@ jobs:
     #  run: cd ${PARPE_BUILD} && CTEST_OUTPUT_ON_FAILURE=1 make test
 
     - name: Create coverage report
+      env:
+        LD_DEBUG: bindings
       run: |
         cd ${PARPE_BUILD} \
           && CTEST_OUTPUT_ON_FAILURE=1 make parpe_coverage \

--- a/.github/workflows/parpe_tests.yml
+++ b/.github/workflows/parpe_tests.yml
@@ -58,10 +58,9 @@ jobs:
           -DBUILD_TESTS=OFF \
           && cmake --build "${AMICI_PATH}/build" --parallel -- VERBOSE=1
 
-    - name: Install parPE Python deps
+    - name: Install parPE deps
       run: |
-        pip install -r ${PARPE_BASE}/python/requirements.txt \
-          && sudo apt install lcov
+        sudo apt install lcov
 
     - name: "Install parPE deps: fides"
       run: |

--- a/.github/workflows/petab_testsuite.yml
+++ b/.github/workflows/petab_testsuite.yml
@@ -36,10 +36,6 @@ jobs:
             -DBUILD_TESTS=OFF \
           && cmake --build "${AMICI_PATH}/build" --parallel -- VERBOSE=1
 
-    - name: Install parPE Python deps
-      run: |
-        pip install -r ${PARPE_BASE}/python/requirements.txt
-
     - name: Configure parpe
       run: |
         cmake \

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -157,7 +157,7 @@ function(SETUP_TARGET_FOR_COVERAGE)
         COMMAND ${Coverage_EXECUTABLE}
 
         # Capturing lcov counters and generating report
-        COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info
+        COMMAND ${LCOV_PATH} --directory . --capture --output-file ${Coverage_NAME}.info --ignore-errors mismatch
         COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.info ${COVERAGE_EXCLUDES} --output-file ${Coverage_NAME}.info.cleaned
         COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${Coverage_NAME}.info.cleaned
         COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.info ${Coverage_NAME}.info.cleaned

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -41,6 +41,9 @@
 # 2017-06-02, Lars Bilke
 # - Merged with modified version from github.com/ufz/ogs
 #
+# 2024-10-13, Daniel Weindl
+# - Added "--ignore-errors mismatch" to lcov command to ignore errors with
+#   recent gcc
 #
 # USAGE:
 #

--- a/container/charliecloud/parpe_base/Dockerfile
+++ b/container/charliecloud/parpe_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 COPY . /container-files
 

--- a/container/charliecloud/parpe_base/Dockerfile
+++ b/container/charliecloud/parpe_base/Dockerfile
@@ -9,7 +9,6 @@ ENV CC clang
 ENV CXX clang++
 ENV OMPI_CC clang
 ENV OMPI_CXX clang++
-
 RUN /container-files/install_parpe.sh
 
 ENV PARPE_DIR "/parPE"

--- a/container/charliecloud/parpe_base/install.sh
+++ b/container/charliecloud/parpe_base/install.sh
@@ -39,10 +39,6 @@ apt-get install -q -y \
   unzip \
   wget
 
-# for setuptools to find:
-python3 -m pip install --upgrade pip
-pip3 install -U setuptools pkgconfig wheel
-
 echo "================= Cleaning package lists ==================="
 apt-get clean
 apt-get autoclean

--- a/container/charliecloud/parpe_base/install_parpe.sh
+++ b/container/charliecloud/parpe_base/install_parpe.sh
@@ -26,9 +26,6 @@ cmake \
 # install fides optimizer
 cd "$PARPE_BASE/ThirdParty" && ./installFides.sh
 
-# install parPE python requirements
-pip3 install -r "${PARPE_BASE}"/python/requirements.txt
-
 # build parPE
 cd "${PARPE_BASE}"
 mkdir -p build

--- a/container/charliecloud/parpe_base/install_parpe.sh
+++ b/container/charliecloud/parpe_base/install_parpe.sh
@@ -42,7 +42,7 @@ mpi_cmd="$mpi_cmd;--mca;oob_tcp_if_include;lo"
 mpi_cmd="$mpi_cmd;--mca;btl_tcp_if_include;lo;"
 mpi_cmd="$mpi_cmd;--mca;orte_base_help_aggregate;0"
 
-CC=mpicc CXX=mpiCC cmake \
+cmake \
       -DPARPE_BUILD_OPTIMIZED=OFF \
       -DPARPE_ENABLE_FIDES=ON \
       -DIPOPT_INCLUDE_DIRS=/usr/include/coin/ \

--- a/examples/parpeamici/steadystate/CMakeLists.txt
+++ b/examples/parpeamici/steadystate/CMakeLists.txt
@@ -80,6 +80,8 @@ set(SRC_LIST_EXE_PARALLEL
 add_executable(${PROJECT_NAME} ${SRC_LIST_EXE_PARALLEL})
 add_dependencies(${PROJECT_NAME} ${MODEL_NAME})
 target_link_libraries(${PROJECT_NAME}
+    PRIVATE $<$<BOOL:${PARPE_ENABLE_MPI}>:MPI::MPI_CXX>
+    $<$<BOOL:${PARPE_ENABLE_MPI}>:MPI::MPI_C>
     ${MODEL_LIBRARIES}
     parpeamici
     ${GCOV_LIBRARY}

--- a/examples/parpeamici/steadystate/CMakeLists.txt
+++ b/examples/parpeamici/steadystate/CMakeLists.txt
@@ -80,8 +80,6 @@ set(SRC_LIST_EXE_PARALLEL
 add_executable(${PROJECT_NAME} ${SRC_LIST_EXE_PARALLEL})
 add_dependencies(${PROJECT_NAME} ${MODEL_NAME})
 target_link_libraries(${PROJECT_NAME}
-    PRIVATE $<$<BOOL:${PARPE_ENABLE_MPI}>:MPI::MPI_CXX>
-    $<$<BOOL:${PARPE_ENABLE_MPI}>:MPI::MPI_C>
     ${MODEL_LIBRARIES}
     parpeamici
     ${GCOV_LIBRARY}

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,0 @@
-termcolor

--- a/src/parpeamici/CMakeLists.txt
+++ b/src/parpeamici/CMakeLists.txt
@@ -37,11 +37,11 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-    PUBLIC parpeoptimization
     PUBLIC parpeloadbalancer
     PUBLIC parpecommon
     PUBLIC Upstream::amici
     PUBLIC ${Boost_SERIALIZATION_LIBRARY_RELEASE}
+    PUBLIC parpeoptimization
 )
 
 if (${OpenMP_FOUND})

--- a/src/parpeamici/CMakeLists.txt
+++ b/src/parpeamici/CMakeLists.txt
@@ -41,6 +41,17 @@ target_link_libraries(${PROJECT_NAME}
     PUBLIC parpecommon
     PUBLIC Upstream::amici
     PUBLIC ${Boost_SERIALIZATION_LIBRARY_RELEASE}
+    # For not fully understood reasons, `parpeoptimization` needs to come last.
+    # There was an issue with the Ubuntu 24.04 ipopt package, which is pulling
+    # in libdmumps_seq-5.6.so, which exports dummy MPI_* symbols that cause
+    # problems when building parpe with MPI. Run-time resolution would pick up
+    # the incorrect MPI symbols. We need to make sure that MPI::MPI_C linker
+    # flags come first, but CMake first lists all direct dependencies, and only
+    # then the transitive dependencies (in this case, in an unfortunate order).
+    # INTERFACE_LINK_LIBRARIES_DIRECT did not help.
+    # Note that in this case, parpe should *not* be compiled with the MPI
+    # compiler wrappers (mpicc, mpicxx), because this will prevent CMake from
+    # adding the MPI linker flags.
     PUBLIC parpeoptimization
 )
 

--- a/tests/parpe.supp
+++ b/tests/parpe.supp
@@ -518,3 +518,18 @@
    fun:orte_init
    ...
 }
+
+
+{
+   fides_cpp
+   Memcheck:BadSize
+   fun:posix_memalign
+   fun:_ZN5blaze15alignedAllocateEmm
+   fun:_ZN5blaze16AlignedAllocatorIdE8allocateEm
+   fun:_ZN5blaze13DynamicMatrixIdLb0ENS_16AlignedAllocatorIdEENS_8GroupTagILm0EEEEC1EmmmmRKS2_NS5_13UninitializedE
+   fun:_ZN5blaze13DynamicMatrixIdLb0ENS_16AlignedAllocatorIdEENS_8GroupTagILm0EEEEC1EmmmRKS2_NS5_13UninitializedE
+   fun:_ZN5blaze13DynamicMatrixIdLb0ENS_16AlignedAllocatorIdEENS_8GroupTagILm0EEEEC1EmmRKS2_
+   fun:_ZN5blaze13DynamicMatrixIdLb0ENS_16AlignedAllocatorIdEENS_8GroupTagILm0EEEEC1ERKS5_
+   fun:_ZN5fides9Optimizer11do_minimizeEv
+   ...
+}

--- a/tests/parpe.supp
+++ b/tests/parpe.supp
@@ -84,7 +84,7 @@
    libhwloc
    Memcheck:Leak
    match-leak-kinds: all
-   fun:calloc
+   fun:*alloc
    ...
    obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.*.*
    ...
@@ -447,7 +447,7 @@
    fun:_ZN2H58PredTypeC1El
    fun:_ZN2H58PredType13makePredTypesEv
    fun:_ZN2H58PredType12getPredTypesEv
-   obj:/usr/lib/x86_64-linux-gnu/libhdf5_serial_cpp.so.103.3.0
+   obj:/usr/lib/x86_64-linux-gnu/libhdf5_serial_cpp.so.*
 }
 
 


### PR DESCRIPTION
* Use Ubuntu 24.04 (also https://github.com/ICB-DCM/custom_ci_image/commit/795e527bc8f9e870c272d7bf37aaff4be4a46d10)
* Don't attempt to install Python packages with system-Python
* Ensure dummy `MPI_*` functions from `libdmumps_seq-5.6.so` via IpOpt don't shadow proper MPI functions
* <details><summary>Fix some Issue with lcov/geninfo when creating coverate reports</summary>
  <p>
  <pre>
  Test time (real) =  21.72 sec
  Capturing coverage data from .
  geninfo cmd: '/usr/bin/geninfo . --output-filename parpe_coverage.info --memory 0'
  Found gcov version: 13.2.0
  Using intermediate gcov format
  Writing temporary data to /tmp/geninfo_dato54m
  Scanning . for .gcda files ...
  Found 58 data files in .
  Processing ./tests/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.gcda
  Processing ./tests/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.gcda
  geninfo: WARNING: /usr/include/c++/13/bits/hashtable_policy.h:333: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
  Processing ./tests/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.gcda
  geninfo: WARNING: /usr/include/c++/13/bits/alloc_traits.h:517: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	  (use "geninfo --ignore-errors gcov,gcov ..." to suppress this warning)
  Processing ./tests/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.gcda
  Processing ./tests/parpecommon/CMakeFiles/unittests_common.dir/commonTests.cpp.gcda
  geninfo: WARNING: /usr/include/c++/13/bits/stl_iterator_base_types.h:240: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	  (use "geninfo --ignore-errors gcov,gcov ..." to suppress this warning)
  geninfo: ERROR: mismatched end line for _ZN26Testing_TenToMinusInf_Test8TestBodyEv at /__w/parPE/parPE/tests/parpecommon/commonTests.cpp:21: 21 -> 23
	  (use "geninfo --ignore-errors mismatch ..." to bypass this error)
  make[3]: *** [CMakeFiles/parpe_coverage.dir/build.make:77: CMakeFiles/parpe_coverage] Error 1
  make[2]: *** [CMakeFiles/Makefile2:1192: CMakeFiles/parpe_coverage.dir/all] Error 2
  make[1]: *** [CMakeFiles/Makefile2:1199: CMakeFiles/parpe_coverage.dir/rule] Error 2
  make: *** [Makefile:576: parpe_coverage] Error 2
  </pre>
  </p>
  </details> 
* Update valgrind suppressions