### PR TITLE
PEtab import: option to ignore initialization prior

### DIFF
--- a/benchmark_collection/import_and_run.sh
+++ b/benchmark_collection/import_and_run.sh
@@ -73,7 +73,8 @@ cmd="parpe_petab_to_hdf5 \
     -o ${hdf5_infile} \
     -d ${amici_model_dir} \
     -y ${petab_model_dir}/${model_name}.yaml \
-    -n ${model_name}"
+    -n ${model_name} \
+    --ignore-initialization-priors"
 echo "$cmd"
 $cmd
 

--- a/python/parpe/hdf5_pe_input.py
+++ b/python/parpe/hdf5_pe_input.py
@@ -1162,6 +1162,12 @@ def parse_cli_args():
                         help='Flatten measurement specific overrides of '
                              'observable and noise parameters')
 
+    parser.add_argument('--ignore-initialization-priors',
+                        dest='ignore_initialization_prior', default=False,
+                        action='store_true',
+                        help='Ignore unsupported initialization prior in '
+                             'PEtab problem')
+
     return parser.parse_args()
 
 
@@ -1175,6 +1181,13 @@ def main():
     args = parse_cli_args()
 
     petab_problem = petab.Problem.from_yaml(args.petab_yaml)
+
+    if args.ignore_initialization_prior:
+        # delete initialization prior columns if they exist
+        for col in [ptc.INITIALIZATION_PRIOR_TYPE,
+                    ptc.INITIALIZATION_PRIOR_PARAMETERS]:
+            if col in petab_problem.parameter_df:
+                del petab_problem.parameter_df[col]
 
     if args.flatten:
         petab.flatten_timepoint_specific_output_overrides(petab_problem)


### PR DESCRIPTION
Add an option to just ignore (currently unsupported) initialization priors instead of failing.