### PR TITLE
PEtab: Fix initial state from condition table

### DIFF
--- a/tests/petab-test-suite/test_petab_test_suite.py
+++ b/tests/petab-test-suite/test_petab_test_suite.py
@@ -120,10 +120,6 @@ def _test_case(case: Union[int, str]) -> None:
     assert llh_actual == pytest.approx(gt_llh,
                                        rel=solution[petabtests.TOL_LLH])
 
-    # FIXME
-    #  0011 init conc condition table
-    #  0013 parametric init conc condition table
-
 
 def run() -> None:
     """Run the full PEtab test suite"""


### PR DESCRIPTION
Initial state specified via the PEtab condition table was not always handled correctly when there was a NaN in condition table (meaning that the model value should be used).


The parameter mapping code here did not fully keep up with PEtab developments. Most of the required functionality is meanwhile available through AMICI. Use that instead of repeating everything here.